### PR TITLE
Enhance `import` and `imports` to support importing from absolute paths to directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,9 @@ job "baz" {
 }
 ```
 
-Okay that works. But you ended up too many files in a single directory? `import = "path/to/dir"` can be used to load all the `*.variant` files in the directory into the current `job`.
+Okay that works. But you ended up too many files in a single directory?
+
+A "parent" variant file containing `import` or `imports` can be used to load all the `*.variant` files in the directory into the current `job`.
 
 `path/to/yourcmd.variant`:
 ```hcl
@@ -259,6 +261,14 @@ parameter "param1" {
 
 # snip
 ```
+
+Note that `imports` is the newer variant of `import` that supports multiple sources to be imported.
+
+Also, you can import following sources:
+
+- Relative path to local directory (A local path that doesn't start with `/`, like `foo/bar`)
+- Absolute path to local directory (An absolute path that starts with `/`, like `/variant/modules/example.com/foo/bar`)
+- URLs to Git repository (`REPO_URL@PATH/TO/DIR?ref=BRANCH`, e.g. `git::ssh://git@github.com/mumoshu/variant2@examples/advanced/import/foo?ref=master`)
 
 See the [import](/examples/advanced/import) example for the full declaration of this command for reference.
 

--- a/pkg/app/load.go
+++ b/pkg/app/load.go
@@ -165,20 +165,24 @@ func New(setup Setup) (*App, error) {
 		return app, err
 	}
 
-	return newApp(app, cc, NewImportFunc(instance.Dir))
+	return newApp(app, cc, NewImportFunc(instance.Dir, func(path string) (*App, error) {
+		return New(FromDir(path))
+	}))
 }
 
-func NewImportFunc(importBaseDir string) func(string) (*App, error) {
+func NewImportFunc(importBaseDir string, f func(string) (*App, error)) func(string) (*App, error) {
 	return func(dir string) (*App, error) {
 		var d string
 
 		if strings.Contains(dir, ":") {
 			d = dir
+		} else if dir[0] == '/' {
+			d = dir
 		} else {
 			d = filepath.Join(importBaseDir, dir)
 		}
 
-		return New(FromDir(d))
+		return f(d)
 	}
 }
 

--- a/pkg/app/load_test.go
+++ b/pkg/app/load_test.go
@@ -1,0 +1,55 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestNewImportFunc(t *testing.T) {
+	type testcase struct {
+		subject string
+		path    string
+		want    string
+	}
+
+	testcases := []testcase{
+		{
+			subject: "relative path",
+			path:    "foo/bar",
+			want:    "sub/foo/bar",
+		},
+		{
+			subject: "git url",
+			path:    "git::ssh://git@github.com/mumoshu/variant2@examples/advanced/import/foo?ref=master",
+			want:    "git::ssh://git@github.com/mumoshu/variant2@examples/advanced/import/foo?ref=master",
+		},
+		{
+			subject: "absolute path",
+			path:    "/a/b/c",
+			want:    "/a/b/c",
+		},
+	}
+
+	for i := range testcases {
+		tc := testcases[i]
+
+		t.Run(tc.subject, func(t *testing.T) {
+			a := &App{}
+
+			f := NewImportFunc("sub", func(path string) (*App, error) {
+				if d := cmp.Diff(tc.want, path); d != "" {
+					t.Errorf("%s: %s", tc.subject, d)
+				}
+
+				return a, nil
+			})
+
+			r, _ := f(tc.path)
+
+			if r != a {
+				t.Fatalf("%s: unexpected result returned", tc.subject)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`import` and `imports` only supported relative paths to local directories or Git URLs before.

Since this change, it accepts a configuration like the below:

```
imports = [
  "/variant/modules/mycommmand/myjob/mynestedjob"
]
```
