### PR TITLE
Fix run via shebang to not fail due to redundant/repeated args

### DIFF
--- a/variant.go
+++ b/variant.go
@@ -140,9 +140,7 @@ func GetPathAndArgsFromEnv(env Env) (string, string, []string) {
 		info, err := os.Stat(file)
 
 		if err == nil && info != nil && !info.IsDir() {
-			if len(osArgs) > 2 {
-				osArgs = osArgs[2:]
-			}
+			osArgs = osArgs[2:]
 
 			path = file
 			cmd = filepath.Base(file)


### PR DESCRIPTION
There was a regression in the shebang support, that resulted in `./myapp` to be internally treated as `variant run variant run myapp`, which hs been giving you `Error: accepts between 0 and 0 arg(s), received 2` errors.
