### PR TITLE
Fix import/imports not importing non-top-level jobs via shebang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,33 @@
 name: Go
 on: [push]
 jobs:
-  build:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+        - 1.13.4
+    name: Go ${{ matrix.go }} build
+    steps:
+    - uses: actions/checkout@master
+    - name: Setup Go
+      uses: actions/setup-go@v1
+      with:
+        version: ${{ matrix.go }}
+    - name: Run go mod download
+      run: go mod download
+    - name: Install SSH key
+      uses: shimataro/ssh-key-action@v2
+      with:
+        key: ${{ secrets.SSH_KEY }}
+        known_hosts: ${{ secrets.KNOWN_HOSTS }}
+    - name: Run tests
+      run: |
+        which kubectl
+        sudo apt-get update -y
+        sudo apt-get install ruby -y
+        make test smoke
+  lint:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -18,14 +44,3 @@ jobs:
       run: go mod download
     - name: Run golangci-lint
       run: make lint
-    - name: Install SSH key
-      uses: shimataro/ssh-key-action@v2
-      with:
-        key: ${{ secrets.SSH_KEY }}
-        known_hosts: ${{ secrets.KNOWN_HOSTS }}
-    - name: Run tests
-      run: |
-        which kubectl
-        sudo apt-get update -y
-        sudo apt-get install ruby -y
-        make test smoke

--- a/examples/advanced/import/mycli
+++ b/examples/advanced/import/mycli
@@ -1,0 +1,3 @@
+#!/usr/bin/env variant
+
+import = "."

--- a/examples/module/Dockerfile
+++ b/examples/module/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.10
 
-ARG HELM_VERSION=3.0.0
+ARG HELM_VERSION=3.2.0
 ARG HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
 
 ADD http://storage.googleapis.com/kubernetes-helm/${HELM_FILE_NAME} /tmp

--- a/examples/module/default.variantmod
+++ b/examples/module/default.variantmod
@@ -1,7 +1,7 @@
 module "default" {
   dependency "github_release" "helm" {
     source = "helm/helm"
-    version = "> 1.0.0, < 3.0.1"
+    version = ">= 3.0.0, < 3.2.1"
   }
 
   file "Dockerfile" {

--- a/examples/module/module_test.variant
+++ b/examples/module/module_test.variant
@@ -2,7 +2,7 @@
 test "test" {
   case "ok" {
     out = trimspace(<<EOS
-version.BuildInfo{Version:"v3.0.0", GitCommit:"e29ce2a54e96cd02ccfce88bee4f58bb6e2a28b6", GitTreeState:"clean", GoVersion:"go1.13.4"}
+version.BuildInfo{Version:"v3.2.0", GitCommit:"e11b7ce3b12db2941e90399e874513fbd24bcb71", GitTreeState:"clean", GoVersion:"go1.13.10"}
 EOS
     )
     exitstatus = 0
@@ -25,7 +25,7 @@ test "build" {
     out = trimspace(<<EOS
 FROM alpine:3.10
 
-ARG HELM_VERSION=3.0.0
+ARG HELM_VERSION=3.2.0
 ARG HELM_FILENAME="helm-$${HELM_VERSION}-linux-amd64.tar.gz"
 
 ADD http://storage.googleapis.com/kubernetes-helm/$${HELM_FILE_NAME} /tmp

--- a/main_test.go
+++ b/main_test.go
@@ -140,6 +140,13 @@ func TestExamples(t *testing.T) {
 			wd:          "./examples/advanced/import",
 		},
 		{
+			subject:     "import/shebang",
+			variantName: "",
+			args:        []string{"variant", "./examples/advanced/import/mycli", "foo", "bar", "HELLO"},
+			wd:          "./examples/advanced/import",
+			expectOut:   "HELLO\n",
+		},
+		{
 			subject:     "import-multi",
 			variantName: "",
 			args:        []string{"variant", "test"},
@@ -209,9 +216,13 @@ func TestExamples(t *testing.T) {
 		},
 	}
 
-	for i := range testcases {
+	for idx := range testcases {
+		i := idx
 		tc := testcases[i]
+
 		t.Run(fmt.Sprintf("%d: %s", i, tc.subject), func(t *testing.T) {
+			t.Logf("Running subtest: %d %s", i, tc.subject)
+
 			outRead, outWrite := io.Pipe()
 			env := Env{
 				Args: tc.args,

--- a/pkg/app/load.go
+++ b/pkg/app/load.go
@@ -290,6 +290,8 @@ func newApp(app *App, cc *HCL2Config, importDir func(string) (*App, error)) (*Ap
 						// their types MUST match.
 						merged := mergeJobs(importedJob, j)
 
+						merged.Name = ""
+
 						importedJob = *merged
 					}
 
@@ -321,6 +323,14 @@ func newApp(app *App, cc *HCL2Config, importDir func(string) (*App, error)) (*Ap
 	app.Config = conf
 
 	app.JobByName = jobByName
+
+	var newJobs []JobSpec
+
+	for _, j := range app.JobByName {
+		newJobs = append(newJobs, j)
+	}
+
+	app.Config.Jobs = newJobs
 
 	return app, nil
 }


### PR DESCRIPTION
When run via shebang, `import = "."` from the entry variant file works, but nested `import = "path/to/subdir"` from within variant files imported via the first `import = "."` was apparently ignoring `job`s.