### PR TITLE
Pass globals to imported jobs

### DIFF
--- a/examples/advanced/nested-import-global-propagation-default/lib/lib.variant
+++ b/examples/advanced/nested-import-global-propagation-default/lib/lib.variant
@@ -1,0 +1,16 @@
+option "project-dir" {
+  description = "Terraform projects directory"
+  default = "./defaultdir"
+  type = string
+}
+
+job "terraform plan" {
+  parameter "project" {
+    type = string
+  }
+
+  exec {
+    command = "bash"
+    args    = ["-c", "echo ${opt.project-dir}/${param.project}"]
+  }
+}

--- a/examples/advanced/nested-import-global-propagation-default/main.variant
+++ b/examples/advanced/nested-import-global-propagation-default/main.variant
@@ -1,0 +1,3 @@
+job "nested" {
+  import = "lib"
+}

--- a/examples/advanced/nested-import-global-propagation-incompatible-type/lib/lib.variant
+++ b/examples/advanced/nested-import-global-propagation-incompatible-type/lib/lib.variant
@@ -1,0 +1,16 @@
+option "project-dir" {
+  description = "Terraform projects directory"
+  default = "./defaultdir"
+  type = string
+}
+
+job "terraform plan" {
+  parameter "project" {
+    type = string
+  }
+
+  exec {
+    command = "bash"
+    args    = ["-c", "echo ${opt.project-dir}/${param.project}"]
+  }
+}

--- a/examples/advanced/nested-import-global-propagation-incompatible-type/main.variant
+++ b/examples/advanced/nested-import-global-propagation-incompatible-type/main.variant
@@ -1,0 +1,10 @@
+option "project-dir" {
+  # The default works from geodesic shell `projects` folder
+  default = 1
+  description = "Terraform projects directory"
+  type = number
+}
+
+job "nested" {
+  import = "lib"
+}

--- a/examples/advanced/nested-import-global-propagation/defaultdir/project
+++ b/examples/advanced/nested-import-global-propagation/defaultdir/project
@@ -1,0 +1,1 @@
+DEFAULT

--- a/examples/advanced/nested-import-global-propagation/lib/lib.variant
+++ b/examples/advanced/nested-import-global-propagation/lib/lib.variant
@@ -1,0 +1,16 @@
+option "project-dir" {
+  description = "Terraform projects directory"
+  default = "./defaultdir"
+  type = string
+}
+
+job "terraform plan" {
+  parameter "project" {
+    type = string
+  }
+
+  exec {
+    command = "bash"
+    args    = ["-c", "echo ${opt.project-dir}/${param.project}"]
+  }
+}

--- a/examples/advanced/nested-import-global-propagation/main.variant
+++ b/examples/advanced/nested-import-global-propagation/main.variant
@@ -1,0 +1,10 @@
+option "project-dir" {
+  # The default works from geodesic shell `projects` folder
+  default = "./overridedir"
+  description = "Terraform projects directory"
+  type = string
+}
+
+job "nested" {
+  import = "lib"
+}

--- a/examples/advanced/nested-import-global-propagation/overridedir/project
+++ b/examples/advanced/nested-import-global-propagation/overridedir/project
@@ -1,0 +1,1 @@
+OVERRIDE

--- a/main.go
+++ b/main.go
@@ -1,5 +1,7 @@
 package variant
 
+import "fmt"
+
 func RunMain(env Env, opts ...Option) error {
 	cmd, path, args := GetPathAndArgsFromEnv(env)
 
@@ -11,7 +13,7 @@ func RunMain(env Env, opts ...Option) error {
 		}
 	}))
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("loading command: %w", err)
 	}
 
 	return m.Run(args, RunOptions{DisableLocking: false})

--- a/main_test.go
+++ b/main_test.go
@@ -155,6 +155,27 @@ func TestExamples(t *testing.T) {
 			wd:          "./examples/advanced/import-multi",
 		},
 		{
+			subject:     "nested-import-global-propagation",
+			args:        []string{"variant", "run", "nested", "terraform", "plan", "project"},
+			variantName: "",
+			wd:          "./examples/advanced/nested-import-global-propagation",
+			expectOut:   "./overridedir/project\n",
+		},
+		{
+			subject:     "nested-import-global-propagation-default",
+			args:        []string{"variant", "run", "nested", "terraform", "plan", "project"},
+			variantName: "",
+			wd:          "./examples/advanced/nested-import-global-propagation-default",
+			expectOut:   "./defaultdir/project\n",
+		},
+		{
+			subject:     "nested-import-global-propagation-incompatible-type",
+			args:        []string{"variant", "run", "nested", "terraform", "plan", "project"},
+			variantName: "",
+			wd:          "./examples/advanced/nested-import-global-propagation-incompatible-type",
+			expectErr:   "loading command: merging globals: imported job \"\" has incompatible option \"project-dir\": needs type of cty.Number, encountered cty.String",
+		},
+		{
 			subject:     "options",
 			variantName: "",
 			args:        []string{"variant", "test"},
@@ -292,8 +313,8 @@ func TestExamples(t *testing.T) {
 			if tc.expectErr != "" {
 				if err == nil {
 					t.Fatalf("Expected error didn't occur")
-				} else if err.Error() != tc.expectErr {
-					t.Fatalf("Unexpected error: want %q, got %q\n%s", tc.expectErr, err.Error(), errOut)
+				} else if d := cmp.Diff(tc.expectErr, err.Error()); d != "" {
+					t.Fatalf("Unexpected error:\nDIFF:\n%s\nSTDERR:\n%s", d, errOut)
 				}
 			} else if err != nil {
 				t.Fatalf("%+v\n%s", err, errOut)


### PR DESCRIPTION
Imported variant command's globals (top-level parameters and options) are now merged into the command, when it misses parameters and options with the same names.

If any imported global's type conflict with the command's corresponding parameter/option type, it fails early so that the imported command doesn't fail due to unexpected value/type provided.

Resolves #29