### PR TITLE
Merge configs by overriding with empty values

### DIFF
--- a/examples/config/conf/defaults.yaml
+++ b/examples/config/conf/defaults.yaml
@@ -1,0 +1,1 @@
+region: us-east-2

--- a/examples/config/conf/dev.yaml
+++ b/examples/config/conf/dev.yaml
@@ -1,0 +1,2 @@
+env: dev
+region: null

--- a/examples/config/config_test.variant
+++ b/examples/config/config_test.variant
@@ -6,8 +6,8 @@ test "app deploy" {
     exitstatus = 0
     err = ""
     out = <<EOS
-{"app":"app1","bar":"OPT1","env":"prod","getfoo":"app_override,prod,PARAM1","v":"app1prod"}
-{"app":"app1","bar":"OPT1","env":"prod","getfoo":"app_override,prod,PARAM1","v":"app1prod"}
+{"app":"app1","bar":"OPT1","env":"prod","getfoo":"app_override,prod,PARAM1","region":"us-east-2","v":"app1prod"}
+{"app":"app1","bar":"OPT1","env":"prod","getfoo":"app_override,prod,PARAM1","region":"us-east-2","v":"app1prod"}
 EOS
   }
 
@@ -17,8 +17,19 @@ EOS
     exitstatus = 0
     err = ""
     out = <<EOS
-{"app":"app2","bar":"OPT1","env":"prod","getfoo":"app_override,prod,PARAM1","v":"app2"}
-{"app":"app2","bar":"OPT1","env":"prod","getfoo":"app_override,prod,PARAM1","v":"app2"}
+{"app":"app2","bar":"OPT1","env":"prod","getfoo":"app_override,prod,PARAM1","region":"us-east-2","v":"app2"}
+{"app":"app2","bar":"OPT1","env":"prod","getfoo":"app_override,prod,PARAM1","region":"us-east-2","v":"app2"}
+EOS
+  }
+
+  case "app1dev" {
+    app = "app1"
+    env = "dev"
+    exitstatus = 0
+    err = ""
+    out = <<EOS
+{"app":"app1","bar":"OPT1","env":"dev","getfoo":"app_override,dev,PARAM1","region":null,"v":"app1"}
+{"app":"app1","bar":"OPT1","env":"dev","getfoo":"app_override,dev,PARAM1","region":null,"v":"app1"}
 EOS
   }
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/terraform v0.12.18
 	github.com/hectane/go-acl v0.0.0-20190604041725-da78bae5fc95 // indirect
 	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334 // indirect
-	github.com/imdario/mergo v0.3.8
+	github.com/imdario/mergo v0.3.11
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kr/text v0.1.0
 	github.com/leodido/go-urn v1.2.0 // indirect
@@ -41,7 +41,6 @@ require (
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 	golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4 // indirect
 	gopkg.in/go-playground/validator.v9 v9.31.0 // indirect
-	gopkg.in/yaml.v2 v2.2.8 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 	k8s.io/klog v1.0.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -654,6 +654,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.8 h1:CGgOkSJeqMRmt0D9XLWExdT4m4F1vd3FV3VPt+0VxkQ=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
+github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb v0.0.0-20190411212539-d24b7ba8c4c4 h1:3K3KcD4S6/Y2hevi70EzUTNKOS3cryQyhUnkjE6Tz0w=
@@ -1463,6 +1465,8 @@ gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20190709130402-674ba3eaed22/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20190924164351-c8b7dadae555 h1:4Yrwvx9yMvZx+vK3wdX7aX2UCNZJJn0TDc+BNOJTE00=
 gopkg.in/yaml.v3 v3.0.0-20190924164351-c8b7dadae555/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1475,7 +1475,7 @@ func (app *App) getConfigs(jobCtx *JobContext, cc *HCL2Config, j JobSpec, confTy
 				return cty.NilVal, fmt.Errorf("format %q is not implemented yet. It must be \"yaml\" or omitted", format)
 			}
 
-			if err := mergo.Merge(&merged, m, mergo.WithOverride); err != nil {
+			if err := mergo.Merge(&merged, m, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue); err != nil {
 				return cty.NilVal, err
 			}
 		}


### PR DESCRIPTION
Upgrades mergo to the version that has support for the WithOverwriteWithEmptyValue option that enables merging non-empty values in the destination config with empty values from the source config.

Fixes #33