### PR TITLE
Use the same version of sdk as variant for `variant export`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         which kubectl
         sudo apt-get update -y
         sudo apt-get install ruby -y
-        make test smoke
+        GITHUB_REF=refs/heads/v0.0.0 make test smoke
   lint:
     runs-on: ubuntu-latest
     strategy:
@@ -44,3 +44,24 @@ jobs:
       run: go mod download
     - name: Run golangci-lint
       run: make lint
+  goreleaser-test:
+    runs-on: ubuntu-latest
+    steps:
+    -
+      name: Checkout
+      uses: actions/checkout@v1
+    -
+      name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.15.x
+    -
+      name: Set goreleaser .Env
+      run: |
+        GITHUB_REF=refs/heads/v0.0.0 hack/sdk-vars.sh
+    -
+      name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v1
+      with:
+        version: latest
+        args: release --rm-dist --skip-publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,30 @@ jobs:
         which kubectl
         sudo apt-get update -y
         sudo apt-get install ruby -y
-        GITHUB_REF=refs/heads/v0.0.0 make test smoke
+        GITHUB_REF=refs/heads/v0.0.0 make test
+  smoke:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+        - 1.15.x
+    name: Go ${{ matrix.go }} test
+    steps:
+    - uses: actions/checkout@master
+    - name: Setup Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: ${{ matrix.go }}
+    - name: Run go mod download
+      run: go mod download
+    - name: Install SSH key
+      uses: shimataro/ssh-key-action@v2
+      with:
+        key: ${{ secrets.SSH_KEY }}
+        known_hosts: ${{ secrets.KNOWN_HOSTS }}
+    - name: Run tests
+      run: |
+        GITHUB_REF=refs/heads/v0.0.0 make smoke
   lint:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         go:
         - 1.15.x
-    name: Go ${{ matrix.go }} test
+    name: Go ${{ matrix.go }} smoke test
     steps:
     - uses: actions/checkout@master
     - name: Setup Go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,10 @@ jobs:
       with:
         go-version: 1.15.x
     -
+      name: Set goreleaser .Env
+      run: |
+        hack/sdk-vars.sh
+    -
       name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v1
       with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,8 @@ builds:
   - CGO_ENABLED=0
   ldflags:
   - -s -w -X github.com/mumoshu/variant2/Version={{.Version}}
+  - -X github.com/mumoshu/variant2/pkg/sdk.Version={{.Env.Version}}
+  - -X github.com/mumoshu/variant2/pkg/sdk.ModReplaces={{.Env.ModReplaces}}
 changelog:
   filters:
     # commit messages matching the regexp listed here will be removed from

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,8 +5,8 @@ builds:
   - CGO_ENABLED=0
   ldflags:
   - -s -w -X github.com/mumoshu/variant2/Version={{.Version}}
-  - -X github.com/mumoshu/variant2/pkg/sdk.Version={{.Env.Version}}
-  - -X github.com/mumoshu/variant2/pkg/sdk.ModReplaces={{.Env.ModReplaces}}
+  - -X github.com/mumoshu/variant2/pkg/sdk.Version={{.Env.VERSION}}
+  - -X github.com/mumoshu/variant2/pkg/sdk.ModReplaces={{.Env.MOD_REPLACES}}
 changelog:
   filters:
     # commit messages matching the regexp listed here will be removed from

--- a/Makefile
+++ b/Makefile
@@ -112,13 +112,17 @@ smoke: build
 
 	make build
 	rm -rf build/simple
-	PATH=${PATH}:$(GOBIN) ./variant export go examples/simple build/simple
+	VARIANT_BUILD_VARIANT_REPLACE=$(shell pwd) \
+	  PATH=${PATH}:$(GOBIN) \
+	  ./variant export go examples/simple build/simple
 	cd build/simple; go build -o simple ./
 	build/simple/simple -h | tee smoke.log
 	grep "Namespace to interact with" smoke.log
 
 	rm build/simple/simple
-	PATH=${PATH}:$(GOBIN) ./variant export binary examples/simple build/simple
+	VARIANT_BUILD_VARIANT_REPLACE=$(shell pwd) \
+	  PATH=${PATH}:$(GOBIN) \
+	  ./variant export binary examples/simple build/simple
 	build/simple/simple -h | tee smoke2.log
 	grep "Namespace to interact with" smoke2.log
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,20 @@
+VARIANT_SDK = github.com/mumoshu/variant2/pkg/sdk
+
+# NOTE:
+#   You can test the versioned build with e.g. `GITHUB_REF=refs/heads/v0.36.0 make build`
 .PHONY: build
 build:
-	go build -o variant ./pkg/cmd
+	@echo "Building variant"
+	@{ \
+	set -e ;\
+	source hack/sdk-vars.sh ;\
+	echo Using $(VAARIANT_SDK).Version=$${VERSION} ;\
+	echo Using $(VAARIANT_SDK).ModReplaces=$${MOD_REPLACES} ;\
+	set -x ;\
+	go build \
+	  -ldflags "-X $(VARIANT_SDK).Version=$${VERSION} -X $(VARIANT_SDK).ModReplaces=$${MOD_REPLACES}" \
+	  -o variant ./pkg/cmd ;\
+	}
 
 bin/goimports:
 	echo "Installing goimports"

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build:
 	@echo "Building variant"
 	@{ \
 	set -e ;\
-	source hack/sdk-vars.sh ;\
+	. hack/sdk-vars.sh ;\
 	echo Using $(VAARIANT_SDK).Version=$${VERSION} ;\
 	echo Using $(VAARIANT_SDK).ModReplaces=$${MOD_REPLACES} ;\
 	set -x ;\

--- a/examples/advanced/import-multi/export.sh
+++ b/examples/advanced/import-multi/export.sh
@@ -3,11 +3,13 @@
 PROJECT_ROOT=../../..
 VARIANT=${PROJECT_ROOT}/variant
 
-export VARIANT_BUILD_VER=v0.33.3
+export VARIANT_BUILD_VER=v0.36.0
 export VARIANT_BUILD_VARIANT_REPLACE=$(pwd)/${PROJECT_ROOT}
 
 rm -rf ../exported
 rm -rf ../compiled
+
+export GITHUB_REF=refs/heads/${VARIANT_BUILD_VER}
 
 (cd ${PROJECT_ROOT}; make build)
 ${VARIANT} export go ../import-multi ../exported

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.0.5
 	github.com/PaesslerAG/jsonpath v0.1.1 // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
+	github.com/fluxcd/pkg/apis/meta v0.0.2
 	github.com/fluxcd/pkg/untar v0.0.5
 	github.com/fluxcd/source-controller/api v0.2.0
 	github.com/go-logr/logr v0.2.1
@@ -44,11 +45,14 @@ require (
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/go-playground/validator.v9 v9.31.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
+	k8s.io/api v0.18.9
 	k8s.io/apimachinery v0.18.9
 	k8s.io/client-go v10.0.0+incompatible
 	sigs.k8s.io/controller-runtime v0.6.4
 )
 
+// Required until https://github.com/summerwind/whitebox-controller/pull/8 is merged
 replace github.com/summerwind/whitebox-controller v0.7.1 => github.com/mumoshu/whitebox-controller v0.5.1-0.20201028130131-ac7a0743254b
 
+// Required to fix go mod issue that k8s.io/client-go is somehow "updated" to invalid "v10.0.0+incompatible" on build
 replace k8s.io/client-go v10.0.0+incompatible => k8s.io/client-go v0.18.9

--- a/hack/print-replaces.go
+++ b/hack/print-replaces.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+func main() {
+	content, err := ioutil.ReadFile("go.mod")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	var replaces []string
+
+	for _, l := range strings.Split(string(content), "\n") {
+		if !strings.HasPrefix(l, "replace ") {
+			continue
+		}
+
+		if !strings.Contains(l, " => ") {
+			fmt.Fprintf(os.Stderr, "Unexpected line: ` => ` expected: %s\n", l)
+			os.Exit(1)
+		}
+
+		l = strings.ReplaceAll(l, "replace ", "")
+		l = strings.ReplaceAll(l, " => ", "=")
+		l = strings.ReplaceAll(l, " ", "@")
+		l = strings.TrimRight(l, "\n")
+
+		replaces = append(replaces, l)
+	}
+
+	fmt.Print(strings.Join(replaces, ","))
+}

--- a/hack/sdk-vars.sh
+++ b/hack/sdk-vars.sh
@@ -11,3 +11,8 @@ fi
 
 export VERSION=${tag}
 export MOD_REPLACES=$(go run hack/print-replaces.go)
+
+if [ ! -z "${GITHUB_ENV}" ]; then
+  echo "VERSION=${VERSION}" >> $GITHUB_ENV
+  echo "MOD_REPLACES=${MOD_REPLACES}" >> $GITHUB_ENV
+fi

--- a/hack/sdk-vars.sh
+++ b/hack/sdk-vars.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+tag=${GITHUB_REF##*/}
+
+if [ -z "${tag}" ]; then
+  echo GITHUB_REF must be set 1>&2
+  exit 1
+fi
+
+export VERSION=${tag}
+export MOD_REPLACES=$(go run hack/print-replaces.go)

--- a/pkg/sdk/vars.go
+++ b/pkg/sdk/vars.go
@@ -1,0 +1,5 @@
+package sdk
+
+var Version string
+
+var ModReplaces string


### PR DESCRIPTION
This changes the build script to embed the version number of variant deduced from GITHUB_REF in GitHub Actions, and enhances `variant export` to embed that version in generated go.mod files.

Fixes #36