### PR TITLE
Support for merging multiple config files from variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@ name: goreleaser
 
 on:
   push:
-    branches:
-    - "!*"
     tags:
     - "v*"
 

--- a/examples/advanced/dynamic-config-inheritance/config/globals.yaml
+++ b/examples/advanced/dynamic-config-inheritance/config/globals.yaml
@@ -1,0 +1,5 @@
+vars:
+  namespace: eg
+
+override_with_empty: [1]
+override_with_ints: [1]

--- a/examples/advanced/dynamic-config-inheritance/config/ue2-globals.yaml
+++ b/examples/advanced/dynamic-config-inheritance/config/ue2-globals.yaml
@@ -1,0 +1,9 @@
+import:
+- globals
+
+vars:
+  region: us-east-2
+  environment: ue2
+
+override_with_empty: []
+override_with_ints: [2]

--- a/examples/advanced/dynamic-config-inheritance/config/ue2-prod.yaml
+++ b/examples/advanced/dynamic-config-inheritance/config/ue2-prod.yaml
@@ -1,0 +1,5 @@
+import:
+- ue2-globals
+
+vars:
+  stage: prod

--- a/examples/advanced/dynamic-config-inheritance/config/ue3-prod.yaml
+++ b/examples/advanced/dynamic-config-inheritance/config/ue3-prod.yaml
@@ -1,0 +1,5 @@
+import:
+- ue3-globals
+
+vars:
+  stage: prod

--- a/examples/advanced/dynamic-config-inheritance/main.variant
+++ b/examples/advanced/dynamic-config-inheritance/main.variant
@@ -1,0 +1,48 @@
+option "config-dir" {
+  type = string
+}
+
+job "stack config" {
+  concurrency = 1
+  description = "Generate stack config in YAML format"
+
+  option "stack" {
+    type        = string
+    description = "Stack"
+    short       = "s"
+  }
+
+  variable "configs" {
+    value = flatten(concat([
+      # 1st level of imports
+      for k1, imports1 in yamldecode(file(format("%s/%s.yaml", opt.config-dir, opt.stack))): [
+        for import1 in imports1: concat([
+          # 1st level import's imports = 2nd level of imports
+          for k2, imports2 in yamldecode(file(format("%s/%s.yaml", opt.config-dir, import1))): [
+            for import2 in imports2: [
+              # 2nd level import's imports = 3rd level of imports
+              format("%s/%s.yaml", opt.config-dir, import2)
+            ]
+          ] if k2 == "import"
+        ], [
+          format("%s/%s.yaml", opt.config-dir, import1)
+        ])
+      ] if k1 == "import"
+    ], [
+      format("%s/%s.yaml", opt.config-dir, opt.stack)
+    ]))
+  }
+
+  config "all" {
+    source file {
+      paths = var.configs
+    }
+  }
+
+  exec {
+    command = "echo"
+    args = [
+      jsonencode(conf.all)
+    ]
+  }
+}

--- a/examples/advanced/dynamic-config-inheritance/main_test.variant
+++ b/examples/advanced/dynamic-config-inheritance/main_test.variant
@@ -1,0 +1,82 @@
+test "stack config" {
+  case "ue2-prod" {
+    stack = "ue2-prod"
+    exitstatus = 0
+    err = ""
+    namespace = "eg"
+    region = "us-east-2"
+    environment = "ue2"
+    stage = "prod"
+    override_with_empty = []
+    override_with_ints = [2]
+  }
+
+  // missing stack config
+  case "ue1-prod" {
+    stack = "ue1-prod"
+    exitstatus = 1
+    err = trimspace(<<EOS
+job "stack config": ${abspath("main.variant")}:18,43-50: Invalid function argument; Invalid value for "path" parameter: no file exists at config/ue1-prod.yaml; this function works only with files that are distributed as part of the configuration source code, so if this file will be created by a resource in this configuration you must instead obtain this result from an attribute of that resource.
+EOS
+    )
+    namespace = "UNDEFINED"
+    region = "UNDEFINED"
+    environment = "UNDEFINED"
+    stage = "UNDEFINED"
+    override_with_empty = "UNDEFINED"
+    override_with_ints = "UNDEFINED"
+  }
+
+  // missing stack config import
+  case "ue3-prod" {
+    stack = "ue3-prod"
+    exitstatus = 1
+    err = trimspace(<<EOS
+job "stack config": ${abspath("main.variant")}:21,47-54: Invalid function argument; Invalid value for "path" parameter: no file exists at config/ue3-globals.yaml; this function works only with files that are distributed as part of the configuration source code, so if this file will be created by a resource in this configuration you must instead obtain this result from an attribute of that resource.
+EOS
+    )
+    namespace = "UNDEFINED"
+    region = "UNDEFINED"
+    environment = "UNDEFINED"
+    stage = "UNDEFINED"
+    override_with_empty = "UNDEFINED"
+    override_with_ints = "UNDEFINED"
+  }
+
+  run "stack config" {
+    config-dir = "config"
+    stack = case.stack
+  }
+
+  assert "error" {
+    condition = run.err == case.err
+  }
+
+  assert "namespace" {
+    condition = (run.res.set && try(jsondecode(run.res.stdout).vars.namespace, "UNDEFINED") == case.namespace) || !run.res.set
+  }
+
+  assert "region" {
+    condition = (run.res.set && try(jsondecode(run.res.stdout).vars.region, "UNDEFINED") == case.region) || !run.res.set
+  }
+
+  assert "environment" {
+    condition = (run.res.set && try(jsondecode(run.res.stdout).vars.environment, "UNDEFINED") == case.environment) || !run.res.set
+  }
+
+  assert "stage" {
+    condition = (run.res.set && try(jsondecode(run.res.stdout).vars.stage, "UNDEFINED") == case.stage) || !run.res.set
+  }
+
+  assert "override_with_empty" {
+    condition = (run.res.set && try(jsondecode(run.res.stdout).override_with_empty, "UNDEFINED") == case.override_with_empty) || !run.res.set
+  }
+
+  assert "override_with_ints" {
+    condition = (run.res.set && try(jsondecode(run.res.stdout).override_with_ints, "UNDEFINED") == case.override_with_ints) || !run.res.set
+  }
+
+  assert "exitstatus" {
+    condition = (run.res.set && run.res.exitstatus == case.exitstatus) || !run.res.set
+  }
+}

--- a/examples/advanced/dynamic-config-inheritance/main_test.variant
+++ b/examples/advanced/dynamic-config-inheritance/main_test.variant
@@ -80,3 +80,86 @@ EOS
     condition = (run.res.set && run.res.exitstatus == case.exitstatus) || !run.res.set
   }
 }
+
+test "userfunc stack config" {
+  case "ue2-prod" {
+    stack = "ue2-prod"
+    exitstatus = 0
+    err = ""
+    namespace = "eg"
+    region = "us-east-2"
+    environment = "ue2"
+    stage = "prod"
+    override_with_empty = []
+    override_with_ints = [2]
+  }
+
+  // missing stack config
+  case "ue1-prod" {
+    stack = "ue1-prod"
+    exitstatus = 1
+    err = trimspace(<<EOS
+job "userfunc stack config": ${abspath("userfunc.variant")}:25,13-20: Error in function call; Call to function "import" failed: ${abspath("userfunc.variant")}:4,39-46: Invalid function argument; Invalid value for "path" parameter: no file exists at config/ue1-prod.yaml; this function works only with files that are distributed as part of the configuration source code, so if this file will be created by a resource in this configuration you must instead obtain this result from an attribute of that resource..
+EOS
+    )
+    namespace = "UNDEFINED"
+    region = "UNDEFINED"
+    environment = "UNDEFINED"
+    stage = "UNDEFINED"
+    override_with_empty = "UNDEFINED"
+    override_with_ints = "UNDEFINED"
+  }
+
+  // missing stack config import
+  case "ue3-prod" {
+    stack = "ue3-prod"
+    exitstatus = 1
+    err = trimspace(<<EOS
+job "userfunc stack config": ${abspath("userfunc.variant")}:25,13-20: Error in function call; Call to function "import" failed: ${abspath("userfunc.variant")}:6,9-16: Error in function call; Call to function "import" failed: ${abspath("userfunc.variant")}:4,39-46: Invalid function argument; Invalid value for "path" parameter: no file exists at config/ue3-globals.yaml; this function works only with files that are distributed as part of the configuration source code, so if this file will be created by a resource in this configuration you must instead obtain this result from an attribute of that resource...
+EOS
+    )
+    namespace = "UNDEFINED"
+    region = "UNDEFINED"
+    environment = "UNDEFINED"
+    stage = "UNDEFINED"
+    override_with_empty = "UNDEFINED"
+    override_with_ints = "UNDEFINED"
+  }
+
+  run "userfunc stack config" {
+    config-dir = "config"
+    stack = case.stack
+  }
+
+  assert "error" {
+    condition = run.err == case.err
+  }
+
+  assert "namespace" {
+    condition = (run.res.set && try(jsondecode(run.res.stdout).vars.namespace, "UNDEFINED") == case.namespace) || !run.res.set
+  }
+
+  assert "region" {
+    condition = (run.res.set && try(jsondecode(run.res.stdout).vars.region, "UNDEFINED") == case.region) || !run.res.set
+  }
+
+  assert "environment" {
+    condition = (run.res.set && try(jsondecode(run.res.stdout).vars.environment, "UNDEFINED") == case.environment) || !run.res.set
+  }
+
+  assert "stage" {
+    condition = (run.res.set && try(jsondecode(run.res.stdout).vars.stage, "UNDEFINED") == case.stage) || !run.res.set
+  }
+
+  assert "override_with_empty" {
+    condition = (run.res.set && try(jsondecode(run.res.stdout).override_with_empty, "UNDEFINED") == case.override_with_empty) || !run.res.set
+  }
+
+  assert "override_with_ints" {
+    condition = (run.res.set && try(jsondecode(run.res.stdout).override_with_ints, "UNDEFINED") == case.override_with_ints) || !run.res.set
+  }
+
+  assert "exitstatus" {
+    condition = (run.res.set && run.res.exitstatus == case.exitstatus) || !run.res.set
+  }
+}

--- a/examples/advanced/dynamic-config-inheritance/userfunc.variant
+++ b/examples/advanced/dynamic-config-inheritance/userfunc.variant
@@ -1,0 +1,40 @@
+function "import" {
+  params = [config-dir, path]
+  result = flatten(concat([
+    for k, imports in yamldecode(file(format("%s/%s.yaml", config-dir, path))): [
+      for imported in imports: [
+        import(config-dir, imported)
+      ]
+    ] if k == "import"
+  ], [
+    format("%s/%s.yaml", config-dir, path)
+  ]))
+}
+
+job "userfunc stack config" {
+  concurrency = 1
+  description = "Generate stack config in YAML format"
+
+  option "stack" {
+    type        = string
+    description = "Stack"
+    short       = "s"
+  }
+
+  variable "files" {
+    value = import(opt.config-dir, opt.stack)
+  }
+
+  config "all" {
+    source file {
+      paths = var.files
+    }
+  }
+
+  exec {
+    command = "echo"
+    args = [
+      jsonencode(conf.all)
+    ]
+  }
+}

--- a/examples/advanced/userfunc-local-scope/config/globals.yaml
+++ b/examples/advanced/userfunc-local-scope/config/globals.yaml
@@ -1,0 +1,5 @@
+vars:
+  namespace: eg
+
+override_with_empty: [1]
+override_with_ints: [1]

--- a/examples/advanced/userfunc-local-scope/config/ue2-globals.yaml
+++ b/examples/advanced/userfunc-local-scope/config/ue2-globals.yaml
@@ -1,0 +1,9 @@
+import:
+- globals
+
+vars:
+  region: us-east-2
+  environment: ue2
+
+override_with_empty: []
+override_with_ints: [2]

--- a/examples/advanced/userfunc-local-scope/config/ue2-prod.yaml
+++ b/examples/advanced/userfunc-local-scope/config/ue2-prod.yaml
@@ -1,0 +1,5 @@
+import:
+- ue2-globals
+
+vars:
+  stage: prod

--- a/examples/advanced/userfunc-local-scope/config/ue3-prod.yaml
+++ b/examples/advanced/userfunc-local-scope/config/ue3-prod.yaml
@@ -1,0 +1,5 @@
+import:
+- ue3-globals
+
+vars:
+  stage: prod

--- a/examples/advanced/userfunc-local-scope/main.variant
+++ b/examples/advanced/userfunc-local-scope/main.variant
@@ -1,0 +1,5 @@
+import = "../dynamic-config-inheritance"
+
+job "nested" {
+  import = "../dynamic-config-inheritance"
+}

--- a/examples/advanced/userfunc-local-scope/main_test.variant
+++ b/examples/advanced/userfunc-local-scope/main_test.variant
@@ -1,0 +1,165 @@
+test "imported userfunc stack config" {
+  case "ue2-prod" {
+    stack = "ue2-prod"
+    exitstatus = 0
+    err = ""
+    namespace = "eg"
+    region = "us-east-2"
+    environment = "ue2"
+    stage = "prod"
+    override_with_empty = []
+    override_with_ints = [2]
+  }
+
+  // missing stack config
+  case "ue1-prod" {
+    stack = "ue1-prod"
+    exitstatus = 1
+    err = trimspace(<<EOS
+job "userfunc stack config": ${abspath("../dynamic-config-inheritance/userfunc.variant")}:25,13-20: Error in function call; Call to function "import" failed: ${abspath("../dynamic-config-inheritance/userfunc.variant")}:4,39-46: Invalid function argument; Invalid value for "path" parameter: no file exists at config/ue1-prod.yaml; this function works only with files that are distributed as part of the configuration source code, so if this file will be created by a resource in this configuration you must instead obtain this result from an attribute of that resource..
+EOS
+    )
+    namespace = "UNDEFINED"
+    region = "UNDEFINED"
+    environment = "UNDEFINED"
+    stage = "UNDEFINED"
+    override_with_empty = "UNDEFINED"
+    override_with_ints = "UNDEFINED"
+  }
+
+  // missing stack config import
+  case "ue3-prod" {
+    stack = "ue3-prod"
+    exitstatus = 1
+    err = trimspace(<<EOS
+job "userfunc stack config": ${abspath("../dynamic-config-inheritance/userfunc.variant")}:25,13-20: Error in function call; Call to function "import" failed: ${abspath("../dynamic-config-inheritance/userfunc.variant")}:6,9-16: Error in function call; Call to function "import" failed: ${abspath("../dynamic-config-inheritance/userfunc.variant")}:4,39-46: Invalid function argument; Invalid value for "path" parameter: no file exists at config/ue3-globals.yaml; this function works only with files that are distributed as part of the configuration source code, so if this file will be created by a resource in this configuration you must instead obtain this result from an attribute of that resource...
+EOS
+    )
+    namespace = "UNDEFINED"
+    region = "UNDEFINED"
+    environment = "UNDEFINED"
+    stage = "UNDEFINED"
+    override_with_empty = "UNDEFINED"
+    override_with_ints = "UNDEFINED"
+  }
+
+  run "userfunc stack config" {
+    config-dir = "config"
+    stack = case.stack
+  }
+
+  assert "error" {
+    condition = run.err == case.err
+  }
+
+  assert "namespace" {
+    condition = (run.res.set && try(jsondecode(run.res.stdout).vars.namespace, "UNDEFINED") == case.namespace) || !run.res.set
+  }
+
+  assert "region" {
+    condition = (run.res.set && try(jsondecode(run.res.stdout).vars.region, "UNDEFINED") == case.region) || !run.res.set
+  }
+
+  assert "environment" {
+    condition = (run.res.set && try(jsondecode(run.res.stdout).vars.environment, "UNDEFINED") == case.environment) || !run.res.set
+  }
+
+  assert "stage" {
+    condition = (run.res.set && try(jsondecode(run.res.stdout).vars.stage, "UNDEFINED") == case.stage) || !run.res.set
+  }
+
+  assert "override_with_empty" {
+    condition = (run.res.set && try(jsondecode(run.res.stdout).override_with_empty, "UNDEFINED") == case.override_with_empty) || !run.res.set
+  }
+
+  assert "override_with_ints" {
+    condition = (run.res.set && try(jsondecode(run.res.stdout).override_with_ints, "UNDEFINED") == case.override_with_ints) || !run.res.set
+  }
+
+  assert "exitstatus" {
+    condition = (run.res.set && run.res.exitstatus == case.exitstatus) || !run.res.set
+  }
+}
+
+test "nested userfunc stack config" {
+  case "ue2-prod" {
+    stack = "ue2-prod"
+    exitstatus = 0
+    err = ""
+    namespace = "eg"
+    region = "us-east-2"
+    environment = "ue2"
+    stage = "prod"
+    override_with_empty = []
+    override_with_ints = [2]
+  }
+
+  // missing stack config
+  case "ue1-prod" {
+    stack = "ue1-prod"
+    exitstatus = 1
+    err = trimspace(<<EOS
+job "nested userfunc stack config": ${abspath("../dynamic-config-inheritance/userfunc.variant")}:25,13-20: Error in function call; Call to function "import" failed: ${abspath("../dynamic-config-inheritance/userfunc.variant")}:4,39-46: Invalid function argument; Invalid value for "path" parameter: no file exists at config/ue1-prod.yaml; this function works only with files that are distributed as part of the configuration source code, so if this file will be created by a resource in this configuration you must instead obtain this result from an attribute of that resource..
+EOS
+    )
+    namespace = "UNDEFINED"
+    region = "UNDEFINED"
+    environment = "UNDEFINED"
+    stage = "UNDEFINED"
+    override_with_empty = "UNDEFINED"
+    override_with_ints = "UNDEFINED"
+  }
+
+  // missing stack config import
+  case "ue3-prod" {
+    stack = "ue3-prod"
+    exitstatus = 1
+    err = trimspace(<<EOS
+job "nested userfunc stack config": ${abspath("../dynamic-config-inheritance/userfunc.variant")}:25,13-20: Error in function call; Call to function "import" failed: ${abspath("../dynamic-config-inheritance/userfunc.variant")}:6,9-16: Error in function call; Call to function "import" failed: ${abspath("../dynamic-config-inheritance/userfunc.variant")}:4,39-46: Invalid function argument; Invalid value for "path" parameter: no file exists at config/ue3-globals.yaml; this function works only with files that are distributed as part of the configuration source code, so if this file will be created by a resource in this configuration you must instead obtain this result from an attribute of that resource...
+EOS
+    )
+    namespace = "UNDEFINED"
+    region = "UNDEFINED"
+    environment = "UNDEFINED"
+    stage = "UNDEFINED"
+    override_with_empty = "UNDEFINED"
+    override_with_ints = "UNDEFINED"
+  }
+
+  run "nested userfunc stack config" {
+    config-dir = "config"
+    stack = case.stack
+  }
+
+  assert "error" {
+    condition = run.err == case.err
+  }
+
+  assert "namespace" {
+    condition = (run.res.set && try(jsondecode(run.res.stdout).vars.namespace, "UNDEFINED") == case.namespace) || !run.res.set
+  }
+
+  assert "region" {
+    condition = (run.res.set && try(jsondecode(run.res.stdout).vars.region, "UNDEFINED") == case.region) || !run.res.set
+  }
+
+  assert "environment" {
+    condition = (run.res.set && try(jsondecode(run.res.stdout).vars.environment, "UNDEFINED") == case.environment) || !run.res.set
+  }
+
+  assert "stage" {
+    condition = (run.res.set && try(jsondecode(run.res.stdout).vars.stage, "UNDEFINED") == case.stage) || !run.res.set
+  }
+
+  assert "override_with_empty" {
+    condition = (run.res.set && try(jsondecode(run.res.stdout).override_with_empty, "UNDEFINED") == case.override_with_empty) || !run.res.set
+  }
+
+  assert "override_with_ints" {
+    condition = (run.res.set && try(jsondecode(run.res.stdout).override_with_ints, "UNDEFINED") == case.override_with_ints) || !run.res.set
+  }
+
+  assert "exitstatus" {
+    condition = (run.res.set && run.res.exitstatus == case.exitstatus) || !run.res.set
+  }
+}

--- a/examples/config/config_test.variant
+++ b/examples/config/config_test.variant
@@ -40,7 +40,7 @@ EOS
     exitstatus = 1
     out = ""
     err = trimspace(<<EOS
-job "config view": config "foo": source 1: open examples/config/conf/test.yaml: no such file or directory
+job "config view": config "foo": source 1: open ${abspath("conf/test.yaml")}: no such file or directory
 EOS
     )
   }
@@ -52,7 +52,7 @@ EOS
     exitstatus = 1
     out = ""
     err = trimspace(<<EOS
-job "config view": config "foo": source 2: open examples/config/conf/app3.yaml: no such file or directory
+job "config view": config "foo": source 2: open ${abspath("conf/app3.yaml")}: no such file or directory
 EOS
     )
   }

--- a/examples/secret/secret_test.variant
+++ b/examples/secret/secret_test.variant
@@ -29,7 +29,7 @@ EOS
     exitstatus = 1
     out = ""
     err = trimspace(<<EOS
-job "secret view": secret "foo": source 1: open examples/secret/sec/test.yaml: no such file or directory
+job "secret view": secret "foo": source 1: open ${abspath("sec/test.yaml")}: no such file or directory
 EOS
     )
   }
@@ -41,7 +41,7 @@ EOS
     exitstatus = 1
     out = ""
     err = trimspace(<<EOS
-job "secret view": secret "foo": source 2: open examples/secret/sec/app3.yaml: no such file or directory
+job "secret view": secret "foo": source 2: open ${abspath("sec/app3.yaml")}: no such file or directory
 EOS
     )
   }

--- a/examples/simple/simple_test.variant
+++ b/examples/simple/simple_test.variant
@@ -9,7 +9,7 @@ test "app deploy" {
     namespace = "foo"
     exitstatus = 1
     err = trimspace(<<EOS
-job "app deploy": job "shell": command "bash -c     kubectl -n foo apply -f examples/simple/manifests/
+job "app deploy": job "shell": command "bash -c     kubectl -n foo apply -f ${abspath("manifests")}/
 ": exit status 1
 EOS
     )

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1355,7 +1355,7 @@ func (app *App) createJobContext(cc *HCL2Config, j JobSpec, givenParams map[stri
 	}
 
 	modCtx := &hcl2.EvalContext{
-		Functions: conf.Functions("."),
+		Functions: app.Funcs,
 		Variables: map[string]cty.Value{
 			"param":   cty.ObjectVal(params),
 			"opt":     cty.ObjectVal(opts),

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1354,8 +1354,16 @@ func (app *App) createJobContext(cc *HCL2Config, j JobSpec, givenParams map[stri
 		}
 	}
 
+	funcs := app.Funcs
+
+	if j.Name != "" && app.JobLocalFuncs != nil {
+		if fs, ok := app.JobLocalFuncs[j.Name]; ok {
+			funcs = fs
+		}
+	}
+
 	modCtx := &hcl2.EvalContext{
-		Functions: app.Funcs,
+		Functions: funcs,
 		Variables: map[string]cty.Value{
 			"param":   cty.ObjectVal(params),
 			"opt":     cty.ObjectVal(opts),

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1427,6 +1427,7 @@ func (app *App) createJobContext(cc *HCL2Config, j JobSpec, givenParams map[stri
 	return jobCtx, nil
 }
 
+//nolint:unused
 func (app *App) getConfigs(jobCtx *JobContext, confType string, confSpecs []Config, g func(map[string]interface{}) (map[string]interface{}, error)) (cty.Value, error) {
 	confCtx := jobCtx.evalContext
 
@@ -1434,6 +1435,7 @@ func (app *App) getConfigs(jobCtx *JobContext, confType string, confSpecs []Conf
 
 	for confIndex := range confSpecs {
 		confSpec := confSpecs[confIndex]
+
 		v, err := app.evaluateConfig(jobCtx, confType, confSpec, confCtx, g)
 		if err != nil {
 			return cty.DynamicVal, err
@@ -1524,6 +1526,7 @@ func (app *App) evaluateConfig(jobCtx *JobContext, confType string, confSpec Con
 	return v, nil
 }
 
+//nolint:unused
 func (app *App) addConfigsAndVariablesDeprecated(jobCtx *JobContext, varSpecs []Variable, configs []Config, secrets []Config, g func(m map[string]interface{}) (map[string]interface{}, error)) (*hcl2.EvalContext, error) {
 	conf, err := app.getConfigs(jobCtx, "config", configs, nil)
 	if err != nil {
@@ -1547,14 +1550,14 @@ func (app *App) addConfigsAndVariablesDeprecated(jobCtx *JobContext, varSpecs []
 	return varCtx, nil
 }
 
+//nolint:gocyclo
 func (app *App) addConfigsAndVariables(jobCtx *JobContext, varSpecs []Variable, confSpecs []Config, secSpecs []Config, g func(m map[string]interface{}) (map[string]interface{}, error)) (*hcl2.EvalContext, error) {
 	ctx := jobCtx.evalContext
 
 	type node struct {
-		config       *Config
-		secret       *Config
-		variable     *Variable
-		dependencies []string
+		config   *Config
+		secret   *Config
+		variable *Variable
 	}
 
 	d := dag.New()
@@ -1660,6 +1663,7 @@ func (app *App) addConfigsAndVariables(jobCtx *JobContext, varSpecs []Variable, 
 	confFields := map[string]cty.Value{}
 	secFields := map[string]cty.Value{}
 
+	//nolint:nestif
 	for _, wave := range top {
 		ctx.Variables["var"] = cty.ObjectVal(varFields)
 		ctx.Variables["conf"] = cty.ObjectVal(confFields)
@@ -1755,21 +1759,21 @@ func evaluateVariable(varCtx *hcl2.EvalContext, varSpec Variable) (cty.Value, er
 		}
 
 		return val, nil
-	} else {
-		var v cty.Value
-
-		if err := gohcl2.DecodeExpression(varSpec.Value, varCtx, &v); err != nil {
-			return cty.DynamicVal, err
-		}
-
-		vty := v.Type()
-
-		if !tv.IsNull() && !vty.Equals(tpe) {
-			return cty.DynamicVal, fmt.Errorf("unexpected type of value for variable. want %q, got %q", tpe.FriendlyNameForConstraint(), vty.FriendlyName())
-		}
-
-		return v, nil
 	}
+
+	var v cty.Value
+
+	if err := gohcl2.DecodeExpression(varSpec.Value, varCtx, &v); err != nil {
+		return cty.DynamicVal, err
+	}
+
+	vty := v.Type()
+
+	if !tv.IsNull() && !vty.Equals(tpe) {
+		return cty.DynamicVal, fmt.Errorf("unexpected type of value for variable. want %q, got %q", tpe.FriendlyNameForConstraint(), vty.FriendlyName())
+	}
+
+	return v, nil
 }
 
 func nonEmptyExpression(x hcl2.Expression) bool {

--- a/pkg/app/config_sources.go
+++ b/pkg/app/config_sources.go
@@ -1,0 +1,58 @@
+package app
+
+import (
+	"io/ioutil"
+
+	"github.com/hashicorp/hcl/v2"
+	gohcl2 "github.com/hashicorp/hcl/v2/gohcl"
+)
+
+type configFragment struct {
+	data   []byte
+	key    string
+	format string
+}
+
+func loadFileConfigSource(confCtx *hcl.EvalContext, sourceSpec ConfigSource) ([]configFragment, error) {
+	var source SourceFile
+	if err := gohcl2.DecodeBody(sourceSpec.Body, confCtx, &source); err != nil {
+		return nil, err
+	}
+
+	format := FormatYAML
+
+	var key string
+
+	if source.Key != nil {
+		key = *source.Key
+	}
+
+	var paths []string
+
+	if p := source.Path; p != nil && *p != "" {
+		paths = append(paths, *p)
+	}
+
+	paths = append(paths, source.Paths...)
+
+	var fragments []configFragment
+
+	for _, path := range paths {
+		yamlData, err := ioutil.ReadFile(path)
+		if err != nil {
+			if source.Default == nil {
+				return nil, err
+			}
+
+			yamlData = []byte(*source.Default)
+		}
+
+		fragments = append(fragments, configFragment{
+			data:   yamlData,
+			key:    key,
+			format: format,
+		})
+	}
+
+	return fragments, nil
+}

--- a/pkg/app/config_sources.go
+++ b/pkg/app/config_sources.go
@@ -44,13 +44,17 @@ func loadConfigSourceContent(sourceSpec ConfigSource) (*hcl.BodyContent, error) 
 	schema, partial := gohcl2.ImpliedBodySchema(val.Interface())
 
 	var content *hcl.BodyContent
+
 	var _ hcl.Body
+
 	var diags hcl.Diagnostics
+
 	if partial {
 		content, _, diags = body.PartialContent(schema)
 	} else {
 		content, diags = body.Content(schema)
 	}
+
 	if content == nil {
 		return nil, diags
 	}

--- a/pkg/app/config_sources.go
+++ b/pkg/app/config_sources.go
@@ -5,12 +5,57 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	gohcl2 "github.com/hashicorp/hcl/v2/gohcl"
+	"golang.org/x/xerrors"
 )
 
 type configFragment struct {
 	data   []byte
 	key    string
 	format string
+}
+
+func (app *App) loadJobConfigSource(jobCtx *JobContext, confCtx *hcl.EvalContext, sourceSpec ConfigSource) ([]configFragment, error) {
+	var source SourceJob
+	if err := gohcl2.DecodeBody(sourceSpec.Body, confCtx, &source); err != nil {
+		return nil, xerrors.Errorf("decoding job body: %w", err)
+	}
+
+	args, err := buildArgsFromExpr(jobCtx.WithEvalContext(confCtx).Ptr(), source.Args)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := app.run(jobCtx, nil, source.Name, args, false)
+	if err != nil {
+		return nil, err
+	}
+
+	yamlData := []byte(res.Stdout)
+
+	var (
+		format string
+		key    string
+	)
+
+	if source.Format != nil {
+		format = *source.Format
+	} else {
+		format = FormatYAML
+	}
+
+	if source.Key != nil {
+		key = *source.Key
+	}
+
+	fragments := []configFragment{
+		{
+			data:   yamlData,
+			key:    key,
+			format: format,
+		},
+	}
+
+	return fragments, nil
 }
 
 func loadFileConfigSource(confCtx *hcl.EvalContext, sourceSpec ConfigSource) ([]configFragment, error) {

--- a/pkg/app/types.go
+++ b/pkg/app/types.go
@@ -22,9 +22,10 @@ type ConfigSource struct {
 }
 
 type SourceFile struct {
-	Path    string  `hcl:"path,attr"`
-	Default *string `hcl:"default,attr"`
-	Key     *string `hcl:"key,attr"`
+	Path    *string  `hcl:"path,attr"`
+	Paths   []string `hcl:"paths,optional"`
+	Default *string  `hcl:"default,attr"`
+	Key     *string  `hcl:"key,attr"`
 }
 
 type Step struct {

--- a/pkg/app/types.go
+++ b/pkg/app/types.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty/function"
 
 	"github.com/mumoshu/variant2/pkg/source"
 )
@@ -238,4 +239,6 @@ type App struct {
 	sourceClient *source.Client
 
 	initMu sync.Mutex
+
+	Funcs map[string]function.Function
 }

--- a/pkg/app/types.go
+++ b/pkg/app/types.go
@@ -241,4 +241,6 @@ type App struct {
 	initMu sync.Mutex
 
 	Funcs map[string]function.Function
+
+	JobLocalFuncs map[string]map[string]function.Function
 }


### PR DESCRIPTION
To better support the use-case of dynamically generating configs from other configs and variables, the following changes are made:

- Added `paths` to `file` config source. Either the existing `path` or `paths` is required.
   - All the files listed in `paths` are merged using `mergo` with `mergo.WithOverride` and `mergo.WithOverwriteWithEmptyValue`
- config source's `paths` and `path` can now refer to `var`s. `variant` internally builds a DAG of `var`s, `conf`s, and `sec`s to make it possible.
- Added `function` block to define user-functions, with support for recursive call. Note that user-functions are visible within a variant command that defines it.
  - This means two things:
    - You can't `import` user-functions
    - User-functions defined in the parent variant command are not visible to imported variant commands.
- Added new example for config-depends-on-var use-case at `examples/advanced/dynamic-config-inheritance`
- Added new example for importing variant command with local user-function at `examples/advanced/userfunc-local-scope`

Resolves #42