### PR TITLE
fix(TestDeps): support go v1.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         go:
-        - 1.15.x
+        - 1.16.x
     name: Go ${{ matrix.go }} test
     steps:
     - uses: actions/checkout@master
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         go:
-        - 1.15.x
+        - 1.16.x
     name: Go ${{ matrix.go }} smoke test
     steps:
     - uses: actions/checkout@master
@@ -55,7 +55,7 @@ jobs:
     strategy:
       matrix:
         go:
-        - 1.15.x
+        - 1.16.x
     name: Go ${{ matrix.go }} lint
     steps:
     - uses: actions/checkout@master
@@ -77,7 +77,7 @@ jobs:
       name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.15.x
+        go-version: 1.16.x
     -
       name: Set goreleaser .Env
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.15.x
+        go-version: 1.16.x
     -
       name: Set goreleaser .Env
       run: |

--- a/pkg/app/testdeps_deps.go
+++ b/pkg/app/testdeps_deps.go
@@ -55,6 +55,8 @@ func (TestDeps) WriteProfileTo(name string, w io.Writer, debug int) error {
 	return pprof.Lookup(name).WriteTo(w, debug)
 }
 
+func (TestDeps) SetPanicOnExit0(bool) {}
+
 // ImportPath is the import path of the testing binary, set by the generated main function.
 var ImportPath string
 


### PR DESCRIPTION
Resolves #48 

Create default stub for `func (TestDep) SetPanicOnExit0(bool)`

This was added in go 1.16