### PR TITLE
wip: add validargs for param validation

### DIFF
--- a/examples/validargs/validargs.variant
+++ b/examples/validargs/validargs.variant
@@ -1,0 +1,11 @@
+job "echo" {
+  parameter "color" {
+    type = string
+    validargs = ["red", "yellow"]
+  }
+  
+  exec {
+    command = "echo"
+    args = [param.color]
+  }
+}

--- a/pkg/app/types.go
+++ b/pkg/app/types.go
@@ -77,9 +77,10 @@ type DynamicRun struct {
 type Parameter struct {
 	Name string `hcl:"name,label"`
 
-	Type    hcl.Expression `hcl:"type,attr"`
-	Default hcl.Expression `hcl:"default,attr"`
-	Envs    []EnvSource    `hcl:"env,block"`
+	Type      hcl.Expression `hcl:"type,attr"`
+	Default   hcl.Expression `hcl:"default,attr"`
+	Envs      []EnvSource    `hcl:"env,block"`
+	ValidArgs hcl.Expression `hcl:"validargs,attr"`
 
 	Description *string `hcl:"description,attr"`
 }


### PR DESCRIPTION
Allow param validation with validargs

needs a workaround for this issue in cobra https://github.com/spf13/cobra/issues/745\

i think i need to fix more case for other type (int , list, etc...) but what do you think about this feature?

```
job "echo" {
  parameter "color" {
    type = string
    validargs = ["red", "yellow"]
  }
  
  exec {
    command = "echo"
    args = [param.color]
  }
}

```
Signed-off-by: Tuan Anh Tran <me@tuananh.org>